### PR TITLE
Fix require_once paths in PHP backend

### DIFF
--- a/api/conn.php
+++ b/api/conn.php
@@ -18,8 +18,8 @@ if (php_sapi_name() !== 'cli' && session_status() === PHP_SESSION_NONE) {
 }
 setlocale(LC_ALL, 'es_ES');
 
-require_once('utils.php');
-require_once('api_utils.php');
+require_once __DIR__ . '/utils.php';
+require_once __DIR__ . '/api_utils.php';
 
 class Conexion {
     private static $DB_HOST;

--- a/api/private/Classes/custom_dom_pdf.php
+++ b/api/private/Classes/custom_dom_pdf.php
@@ -1,6 +1,6 @@
 <?php
 
-require_once 'Classes/dompdf/autoload.inc.php';
+require_once __DIR__ . '/dompdf/autoload.inc.php';
 // reference the Dompdf namespace
 use Dompdf\Dompdf;
 
@@ -118,7 +118,6 @@ class CustomDomPDF extends Dompdf {
         $this->html .= '<link rel="stylesheet" href="Classes/css/'.$css.'.css" type="text/css">';
         $this->html .= '</head>';
     }
--
 }
 
 class PlantillaUtils {

--- a/api/private/Classes/custom_php_mailer.php
+++ b/api/private/Classes/custom_php_mailer.php
@@ -4,9 +4,9 @@ use PHPMailer\PHPMailer\PHPMailer;
 use PHPMailer\PHPMailer\Exception;
 
 // require_once('../conn.php');
-require 'phpmailer/src/Exception.php';
-require 'phpmailer/src/PHPMailer.php';
-require 'phpmailer/src/SMTP.php';
+require __DIR__ . '/phpmailer/src/Exception.php';
+require __DIR__ . '/phpmailer/src/PHPMailer.php';
+require __DIR__ . '/phpmailer/src/SMTP.php';
 
 class CustomPHPMailer extends PHPMailer {
 

--- a/api/private/apiClasses/rol.php
+++ b/api/private/apiClasses/rol.php
@@ -10,8 +10,8 @@
  * @version 1.0
  */
 
-require_once('interfaces/crud.php');
-require_once('../conn.php');
+require_once __DIR__ . '/interfaces/crud.php';
+require_once __DIR__ . '/../conn.php';
 
 class Rol extends Conexion implements crud {
 


### PR DESCRIPTION
## Summary
- update relative includes to use `__DIR__` so paths resolve correctly
- fix custom dompdf class syntax issues
- fix custom PHPMailer loader paths

## Testing
- `composer install`
- `php -l api/conn.php`
- `php -l api/private/apiClasses/rol.php`
- `php -l api/private/Classes/custom_dom_pdf.php`
- `php -l api/private/Classes/custom_php_mailer.php`


------
https://chatgpt.com/codex/tasks/task_e_68477a177988832ea09d8bd1c2f75af1